### PR TITLE
Add path-style URL support for MinIO/localhost (v1.1.1)

### DIFF
--- a/src/s3_http.f90
+++ b/src/s3_http.f90
@@ -61,6 +61,7 @@ module s3_http
         character(len=256) :: access_key = ''    !< AWS access key ID (optional for public buckets)
         character(len=256) :: secret_key = ''    !< AWS secret access key (optional for public buckets)
         logical :: use_https = .true.            !< Use HTTPS protocol (recommended)
+        logical :: use_path_style = .false.      !< Use path-style URLs (required for MinIO/localhost)
     end type s3_config
 
     ! Module variables
@@ -229,17 +230,33 @@ contains
         end if
         call s3_log_info(trim(msg))
 
-        ! Build URL
-        if (current_config%use_https) then
-            write(url, '(A,A,A,A,A,A)') 'https://', &
-                trim(current_config%bucket), '.', &
-                trim(current_config%endpoint), '/', &
-                trim(key)
+        ! Build URL - support both virtual-host and path-style
+        if (current_config%use_path_style) then
+            ! Path-style: http://endpoint/bucket/key
+            if (current_config%use_https) then
+                write(url, '(A,A,A,A,A,A)') 'https://', &
+                    trim(current_config%endpoint), '/', &
+                    trim(current_config%bucket), '/', &
+                    trim(key)
+            else
+                write(url, '(A,A,A,A,A,A)') 'http://', &
+                    trim(current_config%endpoint), '/', &
+                    trim(current_config%bucket), '/', &
+                    trim(key)
+            end if
         else
-            write(url, '(A,A,A,A,A,A)') 'http://', &
-                trim(current_config%bucket), '.', &
-                trim(current_config%endpoint), '/', &
-                trim(key)
+            ! Virtual-host style: http://bucket.endpoint/key (original behavior)
+            if (current_config%use_https) then
+                write(url, '(A,A,A,A,A,A)') 'https://', &
+                    trim(current_config%bucket), '.', &
+                    trim(current_config%endpoint), '/', &
+                    trim(key)
+            else
+                write(url, '(A,A,A,A,A,A)') 'http://', &
+                    trim(current_config%bucket), '.', &
+                    trim(current_config%endpoint), '/', &
+                    trim(key)
+            end if
         end if
 
         write(msg, '(A,A)') 'URL: ', trim(url)
@@ -303,17 +320,33 @@ contains
 
         success = .false.
 
-        ! Build URL
-        if (current_config%use_https) then
-            write(url, '(A,A,A,A,A,A)') 'https://', &
-                trim(current_config%bucket), '.', &
-                trim(current_config%endpoint), '/', &
-                trim(key)
+        ! Build URL - support both virtual-host and path-style
+        if (current_config%use_path_style) then
+            ! Path-style: http://endpoint/bucket/key
+            if (current_config%use_https) then
+                write(url, '(A,A,A,A,A,A)') 'https://', &
+                    trim(current_config%endpoint), '/', &
+                    trim(current_config%bucket), '/', &
+                    trim(key)
+            else
+                write(url, '(A,A,A,A,A,A)') 'http://', &
+                    trim(current_config%endpoint), '/', &
+                    trim(current_config%bucket), '/', &
+                    trim(key)
+            end if
         else
-            write(url, '(A,A,A,A,A,A)') 'http://', &
-                trim(current_config%bucket), '.', &
-                trim(current_config%endpoint), '/', &
-                trim(key)
+            ! Virtual-host style: http://bucket.endpoint/key (original behavior)
+            if (current_config%use_https) then
+                write(url, '(A,A,A,A,A,A)') 'https://', &
+                    trim(current_config%bucket), '.', &
+                    trim(current_config%endpoint), '/', &
+                    trim(key)
+            else
+                write(url, '(A,A,A,A,A,A)') 'http://', &
+                    trim(current_config%bucket), '.', &
+                    trim(current_config%endpoint), '/', &
+                    trim(key)
+            end if
         end if
 
         ! Create temp file name
@@ -399,17 +432,33 @@ contains
             return
         end if
 
-        ! Build URL
-        if (current_config%use_https) then
-            write(url, '(A,A,A,A,A,A)') 'https://', &
-                trim(current_config%bucket), '.', &
-                trim(current_config%endpoint), '/', &
-                trim(key)
+        ! Build URL - support both virtual-host and path-style
+        if (current_config%use_path_style) then
+            ! Path-style: http://endpoint/bucket/key
+            if (current_config%use_https) then
+                write(url, '(A,A,A,A,A,A)') 'https://', &
+                    trim(current_config%endpoint), '/', &
+                    trim(current_config%bucket), '/', &
+                    trim(key)
+            else
+                write(url, '(A,A,A,A,A,A)') 'http://', &
+                    trim(current_config%endpoint), '/', &
+                    trim(current_config%bucket), '/', &
+                    trim(key)
+            end if
         else
-            write(url, '(A,A,A,A,A,A)') 'http://', &
-                trim(current_config%bucket), '.', &
-                trim(current_config%endpoint), '/', &
-                trim(key)
+            ! Virtual-host style: http://bucket.endpoint/key (original behavior)
+            if (current_config%use_https) then
+                write(url, '(A,A,A,A,A,A)') 'https://', &
+                    trim(current_config%bucket), '.', &
+                    trim(current_config%endpoint), '/', &
+                    trim(key)
+            else
+                write(url, '(A,A,A,A,A,A)') 'http://', &
+                    trim(current_config%bucket), '.', &
+                    trim(current_config%endpoint), '/', &
+                    trim(key)
+            end if
         end if
 
         ! Create temp file with content
@@ -467,17 +516,33 @@ contains
         exists = .false.
         if (.not. initialized) return
 
-        ! Build URL
-        if (current_config%use_https) then
-            write(url, '(A,A,A,A,A,A)') 'https://', &
-                trim(current_config%bucket), '.', &
-                trim(current_config%endpoint), '/', &
-                trim(key)
+        ! Build URL - support both virtual-host and path-style
+        if (current_config%use_path_style) then
+            ! Path-style: http://endpoint/bucket/key
+            if (current_config%use_https) then
+                write(url, '(A,A,A,A,A,A)') 'https://', &
+                    trim(current_config%endpoint), '/', &
+                    trim(current_config%bucket), '/', &
+                    trim(key)
+            else
+                write(url, '(A,A,A,A,A,A)') 'http://', &
+                    trim(current_config%endpoint), '/', &
+                    trim(current_config%bucket), '/', &
+                    trim(key)
+            end if
         else
-            write(url, '(A,A,A,A,A,A)') 'http://', &
-                trim(current_config%bucket), '.', &
-                trim(current_config%endpoint), '/', &
-                trim(key)
+            ! Virtual-host style: http://bucket.endpoint/key (original behavior)
+            if (current_config%use_https) then
+                write(url, '(A,A,A,A,A,A)') 'https://', &
+                    trim(current_config%bucket), '.', &
+                    trim(current_config%endpoint), '/', &
+                    trim(key)
+            else
+                write(url, '(A,A,A,A,A,A)') 'http://', &
+                    trim(current_config%bucket), '.', &
+                    trim(current_config%endpoint), '/', &
+                    trim(key)
+            end if
         end if
 
         ! Use curl HEAD request to check existence
@@ -527,17 +592,33 @@ contains
             return
         end if
 
-        ! Build URL
-        if (current_config%use_https) then
-            write(url, '(A,A,A,A,A,A)') 'https://', &
-                trim(current_config%bucket), '.', &
-                trim(current_config%endpoint), '/', &
-                trim(key)
+        ! Build URL - support both virtual-host and path-style
+        if (current_config%use_path_style) then
+            ! Path-style: http://endpoint/bucket/key
+            if (current_config%use_https) then
+                write(url, '(A,A,A,A,A,A)') 'https://', &
+                    trim(current_config%endpoint), '/', &
+                    trim(current_config%bucket), '/', &
+                    trim(key)
+            else
+                write(url, '(A,A,A,A,A,A)') 'http://', &
+                    trim(current_config%endpoint), '/', &
+                    trim(current_config%bucket), '/', &
+                    trim(key)
+            end if
         else
-            write(url, '(A,A,A,A,A,A)') 'http://', &
-                trim(current_config%bucket), '.', &
-                trim(current_config%endpoint), '/', &
-                trim(key)
+            ! Virtual-host style: http://bucket.endpoint/key (original behavior)
+            if (current_config%use_https) then
+                write(url, '(A,A,A,A,A,A)') 'https://', &
+                    trim(current_config%bucket), '.', &
+                    trim(current_config%endpoint), '/', &
+                    trim(key)
+            else
+                write(url, '(A,A,A,A,A,A)') 'http://', &
+                    trim(current_config%bucket), '.', &
+                    trim(current_config%endpoint), '/', &
+                    trim(key)
+            end if
         end if
 
         ! Build curl command for DELETE


### PR DESCRIPTION
## Summary

Adds path-style URL support to enable compatibility with MinIO on localhost and other S3-compatible services that require path-style URLs.

## Changes

- **Add `use_path_style` flag to `s3_config`** (default: `false` for AWS compatibility)
- **Update URL construction** in all S3 operations (GET/PUT/DELETE/EXISTS)
  - Path-style: `http://endpoint/bucket/key`
  - Virtual-host (original): `http://bucket.endpoint/key`
- **Add comprehensive tests**:
  - `test_path_style_config`: Verify configuration flag defaults and setting
  - `test_path_style_url_get`: Test path-style GET operations with HTTP/HTTPS

## Motivation

fortran-s3-accessor v1.1.0 only supports virtual-host style URLs (`http://bucket.endpoint/key`), which fails on localhost MinIO because `bucket.localhost` doesn't resolve without DNS configuration.

This blocks:
- Local MinIO integration testing in fortran-s3-netcdf
- Development/testing workflows with S3-compatible services
- Compatibility with Ceph, Wasabi, DigitalOcean Spaces, etc.

## Backwards Compatibility

✅ **Fully backwards compatible**
- Default behavior unchanged (virtual-host style for AWS)
- Existing code works without modification
- New flag is opt-in

## Testing

- All existing tests pass
- 2 new tests added for path-style functionality
- Tested with mock curl infrastructure

## Related Issues

- Fixes fortran-s3-netcdf MinIO integration testing
- Documented in `docs/FORTRAN-S3-ACCESSOR-PATH-STYLE-ISSUE.md` (fortran-s3-netcdf repo)

## Version

This will be released as **v1.1.1** (patch release - adds feature while maintaining full backwards compatibility)

## Summary by Sourcery

Introduce optional path-style URL support in the S3 HTTP module via a new use_path_style flag, ensuring compatibility with MinIO and other S3-compatible services while preserving existing virtual-host URL behavior by default

New Features:
- Add use_path_style flag to s3_config for toggling between path-style and virtual-host S3 URLs
- Support path-style URL construction for all S3 operations (GET, PUT, DELETE, EXISTS)

Tests:
- Add tests for default and configurable use_path_style behavior
- Add tests for HTTP and HTTPS path-style GET requests